### PR TITLE
Non destructive mounts

### DIFF
--- a/usr/bin/shadowblip/init-media
+++ b/usr/bin/shadowblip/init-media
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+if [[ $EUID -ne 0 ]];
+then
+    exec pkexec --disable-internal-agent "$0" "$@"
+fi
+
+exec /usr/lib/media-support/init-media.sh "$@"

--- a/usr/lib/media-support/format-media.sh
+++ b/usr/lib/media-support/format-media.sh
@@ -143,9 +143,11 @@ sync
 mkfs.ext4 -m 0 -O casefold -E "$EXTENDED_OPTIONS" -F "$STORAGE_PARTITION"
 sync
 udevadm settle
+echo "Format complete. Initializing steam library"
 
 # trigger init-media
 /usr/lib/media-support/init-media.sh $STORAGE_PARTITION
+echo "Steam library initialized. Mounting device."
 
 # trigger the mount service
 flock -u "$MOUNT_LOCK_FD"
@@ -155,4 +157,5 @@ if ! systemctl start media-mount@"$STORAGE_PARTBASE".service; then
     exit 5
 fi
 
+echo "All tasks done."
 exit 0

--- a/usr/lib/media-support/format-media.sh
+++ b/usr/lib/media-support/format-media.sh
@@ -143,11 +143,12 @@ sync
 mkfs.ext4 -m 0 -O casefold -E "$EXTENDED_OPTIONS" -F "$STORAGE_PARTITION"
 sync
 udevadm settle
-echo "Format complete. Initializing steam library"
+echo "Format complete."
+echo "Initializing steam library"
 
 # trigger init-media
 /usr/lib/media-support/init-media.sh $STORAGE_PARTITION
-echo "Steam library initialized. Mounting device."
+echo "Mounting device."
 
 # trigger the mount service
 flock -u "$MOUNT_LOCK_FD"

--- a/usr/lib/media-support/format-media.sh
+++ b/usr/lib/media-support/format-media.sh
@@ -51,7 +51,7 @@ fi
 
 # Prompt user is device is internal
 if [[ $(lsblk -d -n -r -o hotplug "$STORAGE_DEVICE") != "1" ]]; then
-    echo "WARNING! $STORAGE_DEVICE is not a hotplug device and may be a system drive.\n"
+    echo "WARNING! $STORAGE_DEVICE is not a hotplug device and may be a system drive."
 fi
 
 STORAGE_PARTBASE="${STORAGE_PARTITION#/dev/}"

--- a/usr/lib/media-support/format-media.sh
+++ b/usr/lib/media-support/format-media.sh
@@ -144,6 +144,9 @@ mkfs.ext4 -m 0 -O casefold -E "$EXTENDED_OPTIONS" -F "$STORAGE_PARTITION"
 sync
 udevadm settle
 
+# trigger init-media
+/usr/lib/media-support/init-media.sh $STORAGE_PARTITION
+
 # trigger the mount service
 flock -u "$MOUNT_LOCK_FD"
 if ! systemctl start media-mount@"$STORAGE_PARTBASE".service; then

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -55,7 +55,7 @@ do_init()
   # Get info for this drive: $ID_FS_LABEL, $ID_FS_UUID, and $ID_FS_TYPE
   if [ $SKIP_MOUNT == 0 ]; then
     # Figure out a mount point to use
-  eval $(/sbin/blkid -o udev ${DEVICE})
+    eval $(/sbin/blkid -o udev ${DEVICE})
     LABEL=${ID_FS_LABEL}
     if [[ -z "${LABEL}" ]]; then
         LABEL=${DEVBASE}

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -68,7 +68,7 @@ do_init()
     /bin/mkdir -p ${mount_point}
 
     ## Mount the device, throw an error if any issue with mounting occurs.
-    if [[ ! /bin/mount -o ${OPTS} ${DEVICE} ${mount_point} ]]; then
+    if ! /bin/mount -o ${OPTS} ${DEVICE} ${mount_point}; then
         echo "Error mounting ${DEVICE} (status = $?)"
         /bin/rmdir ${mount_point}
         exit 1

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -24,7 +24,7 @@ do_init()
   # Avoid mount if part of fstab but not yet mounted.
   for FSTAB_UUID in $(cat /etc/fstab | awk '{ print $1 }' | cut -d "=" -f 2)
   do
-   if [ "$DEVICE_UUID" = "$FSTAB_UUID" ]; then
+   if [[ "$DEVICE_UUID" = "$FSTAB_UUID" ]]; then
      echo "$MEDIA is mounted as part of /etc/fstab. Aborting..."
      exit 1
    fi
@@ -47,7 +47,7 @@ do_init()
   # Prior to talking to mounting, we need all udev hooks to finish, so we know the system has
   # knowledge of the drive. Our rule starts us as a service with --no-block, so we can wait
   # for rules to settle here safely.
-  if ! udevadm settle; then
+  if [[ ! udevadm settle ]]; then
     echo "Failed to wait for \`udevadm settle\`"
     exit 1
   fi
@@ -68,7 +68,7 @@ do_init()
     /bin/mkdir -p ${mount_point}
 
     ## Mount the device, throw an error if any issue with mounting occurs.
-    if [ ! /bin/mount -o ${OPTS} ${DEVICE} ${mount_point} ]; then
+    if [[ ! /bin/mount -o ${OPTS} ${DEVICE} ${mount_point} ]]; then
         echo "Error mounting ${DEVICE} (status = $?)"
         /bin/rmdir ${mount_point}
         exit 1
@@ -77,46 +77,44 @@ do_init()
     echo "Mounted ${DEVICE} at ${mount_point}"
   fi
 
-  if [ -d "${mount_point}/lost+found" ]; then
+  if [[ -d "${mount_point}/lost+found" ]]; then
     rm -rf "${mount_point}/lost+found"
   fi
 
   # Build the file structure manually, if necessary.
   steamapps_dir="${mount_point}/steamapps"
-  if [ ! -d ${steamapps_dir} ]; then
+  if [[ ! -d ${steamapps_dir} ]]; then
     echo "steamapps dir not found. Creating..."
     mkdir ${steamapps_dir}
-    chmod 755 ${steamapps_dir}
   fi
 
   library_file="${mount_point}/libraryfolder.vdf"
-  if [ ! -f ${library_file} ]; then
+  if [[ ! -f ${library_file} ]]; then
     echo "libraryfolder.vdf not found. Creating..."
     echo '"libraryfolder"
   {
   	"contentid"		""
   	"label"		""
   }' > ${library_file}
-    chown 1000:1000 ${library_file}
   fi
 
   desktop_dir="${mount_point}/SteamLibrary"
-  if [ -L ${desktop_dir} ]; then
+  if [[ -L ${desktop_dir} ]]; then
     echo "Removing old symlink to ${desktop_dir}"
     rm ${desktop_dir}
   fi
 
-  if [ ! -d ${desktop_dir} ]; then
+  if [[ ! -d ${desktop_dir} ]]; then
     echo "Desktop Libray not found. Creating..."
     mkdir ${desktop_dir}
   fi
 
-  if [ ! -L "${desktop_dir}/steamapps" ]; then
+  if [[ ! -L "${desktop_dir}/steamapps" ]]; then
     echo "Adding symlink to steamapps dir"
     ln -s ${steamapps_dir} "${desktop_dir}/steamapps"
   fi
 
-  if [ ! -L "${desktop_dir}/libraryfolder.vdf" ]; then
+  if [[ ! -L "${desktop_dir}/libraryfolder.vdf" ]]; then
     echo "Adding symlink to libraryfolder.vdf"
     ln -s ${library_file} "${desktop_dir}/libraryfolder.vdf"
   fi
@@ -127,7 +125,7 @@ do_init()
   chmod 755 "${desktop_dir}/libraryfolder.vdf"
 
   # Clean up if we mounted ourself
-  if [ $SKIP_MOUNT == 0 ]; then
+  if [[ $SKIP_MOUNT == 0 ]]; then
     /bin/umount ${mount_point}
     echo "Unmounted ${DEVICE} from ${mount_point}."
   fi
@@ -135,8 +133,9 @@ do_init()
   exit 0
 }
 
-if [ ! -f $DEVICE ]; then {
+if [[ ! -f $DEVICE ]]; then 
   usage
-}
+fi
+
 do_init
 

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -7,22 +7,17 @@
 
 set -euo pipefail
 
+# Identify drive, any current mounts, and if it is aknown drive.
 DEVBASE=$1
 DEVICE="/dev/${DEVBASE}"
+DEVICE_UUID=$(blkid -o value -s UUID ${DEVICE})
+mount_point=$(/bin/mount | /bin/grep ${PART_PATH} | /usr/bin/awk '{ print $3 }')
 
 usage()
 {
   echo "Usage: $0 partition_name (e.g. sdb1)"
   exit 1
 }
-
-if [ ! -f $DEVICE ]; then {
-  usage
-}
-
-# Identify any current mounts and known drives.
-DEVICE_UUID=$(blkid -o value -s UUID ${DEVICE})
-mount_point=$(/bin/mount | /bin/grep ${PART_PATH} | /usr/bin/awk '{ print $3 }')
 
 do_init()
 {
@@ -137,4 +132,11 @@ do_init()
     echo "Unmounted ${DEVICE} from ${mount_point}."
   fi
   echo "Steam Library initialized."
+  exit 0
 }
+
+if [ ! -f $DEVICE ]; then {
+  usage
+}
+do_init
+

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 DEVBASE=$1
 DEVICE="/dev/${DEVBASE}"
 DEVICE_UUID=$(blkid -o value -s UUID ${DEVICE})
-mount_point=$(/bin/mount | /bin/grep ${PART_PATH} | /usr/bin/awk '{ print $3 }')
+mount_point=$(/bin/mount | /bin/grep ${DEVICE} | /usr/bin/awk '{ print $3 }')
 
 usage()
 {
@@ -55,21 +55,21 @@ do_init()
   # Get info for this drive: $ID_FS_LABEL, $ID_FS_UUID, and $ID_FS_TYPE
   if [ $SKIP_MOUNT == 0 ]; then
     # Figure out a mount point to use
-  eval $(/sbin/blkid -o udev ${PART_PATH})
+  eval $(/sbin/blkid -o udev ${DEVICE})
     LABEL=${ID_FS_LABEL}
     if [[ -z "${LABEL}" ]]; then
-        LABEL=${PART}
+        LABEL=${DEVBASE}
     elif /bin/grep -q " /run/media/${LABEL} " /etc/mtab; then
         # Already in use, make a unique one
-        LABEL+="-${PART}"
+        LABEL+="-${DEVBASE}"
     fi
     mount_point="/run/media/${LABEL}"
 
     /bin/mkdir -p ${mount_point}
 
     ## Mount the device, throw an error if any issue with mounting occurs.
-    if [ ! /bin/mount -o ${OPTS} ${PART_PATH} ${mount_point} ]; then
-        echo "Error mounting ${PART} (status = $?)"
+    if [ ! /bin/mount -o ${OPTS} ${DEVICE} ${mount_point} ]; then
+        echo "Error mounting ${DEVICE} (status = $?)"
         /bin/rmdir ${mount_point}
         exit 1
     fi

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -21,6 +21,7 @@ usage()
 
 do_init()
 {
+  echo "Starting init-media on ${DEVICE}."
   # Avoid mount if part of fstab but not yet mounted.
   for FSTAB_UUID in $(cat /etc/fstab | awk '{ print $1 }' | cut -d "=" -f 2)
   do
@@ -33,8 +34,10 @@ do_init()
   # check if already mounted
   SKIP_MOUNT=0
   if [[ -n ${mount_point} ]]; then
-      echo "${DEVICE} is mounted at ${mount_point}"
-      SKIP_MOUNT=1
+    echo "${DEVICE} is mounted at ${mount_point}"
+    SKIP_MOUNT=1
+  else
+    echo "${DEVICE} is not currently mounted."
   fi
 
   # We need symlinks for Steam for now, so only automount ext4 as that's all
@@ -58,10 +61,10 @@ do_init()
     eval $(/sbin/blkid -o udev ${DEVICE})
     LABEL=${ID_FS_LABEL}
     if [[ -z "${LABEL}" ]]; then
-        LABEL=${DEVBASE}
+      LABEL=${DEVBASE}
     elif /bin/grep -q " /run/media/${LABEL} " /etc/mtab; then
-        # Already in use, make a unique one
-        LABEL+="-${DEVBASE}"
+      # Already in use, make a unique one
+      LABEL+="-${DEVBASE}"
     fi
     mount_point="/run/media/${LABEL}"
 
@@ -69,9 +72,9 @@ do_init()
 
     ## Mount the device, throw an error if any issue with mounting occurs.
     if ! /bin/mount -o ${OPTS} ${DEVICE} ${mount_point}; then
-        echo "Error mounting ${DEVICE} (status = $?)"
-        /bin/rmdir ${mount_point}
-        exit 1
+      echo "Error mounting ${DEVICE} (status = $?)"
+      /bin/rmdir ${mount_point}
+      exit 1
     fi
 
     echo "Mounted ${DEVICE} at ${mount_point}"

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -133,7 +133,7 @@ do_init()
   exit 0
 }
 
-if [[ ! -f $DEVICE ]]; then 
+if [[ ! -n $DEVICE ]]; then 
   usage
 fi
 

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -47,7 +47,7 @@ do_init()
   # Prior to talking to mounting, we need all udev hooks to finish, so we know the system has
   # knowledge of the drive. Our rule starts us as a service with --no-block, so we can wait
   # for rules to settle here safely.
-  if [[ ! udevadm settle ]]; then
+  if  ! udevadm settle; then
     echo "Failed to wait for \`udevadm settle\`"
     exit 1
   fi

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# Originally from https://serverfault.com/a/767079
+# Modified from SteamOS 3 steamos-automount.sh
+# This script is called from our systemd unit file to set up
+# the device as a steam library.
+
+set -euo pipefail
+
+DEVBASE=$1
+DEVICE="/dev/${DEVBASE}"
+
+usage()
+{
+  echo "Usage: $0 partition_name (e.g. sdb1)"
+  exit 1
+}
+
+if [ ! -f $DEVICE ]; then {
+  usage
+}
+
+# Identify any current mounts and known drives.
+DEVICE_UUID=$(blkid -o value -s UUID ${DEVICE})
+mount_point=$(/bin/mount | /bin/grep ${PART_PATH} | /usr/bin/awk '{ print $3 }')
+
+do_init()
+{
+  # Avoid mount if part of fstab but not yet mounted.
+  for FSTAB_UUID in $(cat /etc/fstab | awk '{ print $1 }' | cut -d "=" -f 2)
+  do
+   if [ "$DEVICE_UUID" = "$FSTAB_UUID" ]; then
+     echo "$MEDIA is mounted as part of /etc/fstab. Aborting..."
+     exit 1
+   fi
+  done
+
+  # check if already mounted
+  SKIP_MOUNT=0
+  if [[ -n ${mount_point} ]]; then
+      echo "${DEVICE} is mounted at ${mount_point}"
+      SKIP_MOUNT=1
+  fi
+
+  # We need symlinks for Steam for now, so only automount ext4 as that's all
+  # Steam will format right now
+  #if [[ ${ID_FS_TYPE} != "ext4" ]]; then
+  #  echo "Error mounting ${DEVICE}: wrong fstype: ${ID_FS_TYPE} - ${dev_json}"
+  #  exit 0
+  #fi
+
+  # Prior to talking to mounting, we need all udev hooks to finish, so we know the system has
+  # knowledge of the drive. Our rule starts us as a service with --no-block, so we can wait
+  # for rules to settle here safely.
+  if ! udevadm settle; then
+    echo "Failed to wait for \`udevadm settle\`"
+    exit 1
+  fi
+
+  # Get info for this drive: $ID_FS_LABEL, $ID_FS_UUID, and $ID_FS_TYPE
+  if [ $SKIP_MOUNT == 0 ]; then
+    # Figure out a mount point to use
+  eval $(/sbin/blkid -o udev ${PART_PATH})
+    LABEL=${ID_FS_LABEL}
+    if [[ -z "${LABEL}" ]]; then
+        LABEL=${PART}
+    elif /bin/grep -q " /run/media/${LABEL} " /etc/mtab; then
+        # Already in use, make a unique one
+        LABEL+="-${PART}"
+    fi
+    mount_point="/run/media/${LABEL}"
+
+    /bin/mkdir -p ${mount_point}
+
+    ## Mount the device, throw an error if any issue with mounting occurs.
+    if [ ! /bin/mount -o ${OPTS} ${PART_PATH} ${mount_point} ]; then
+        echo "Error mounting ${PART} (status = $?)"
+        /bin/rmdir ${mount_point}
+        exit 1
+    fi
+
+    echo "Mounted ${DEVICE} at ${mount_point}"
+  fi
+
+  if [ -d "${mount_point}/lost+found" ]; then
+    rm -rf "${mount_point}/lost+found"
+  fi
+
+  # Build the file structure manually, if necessary.
+  steamapps_dir="${mount_point}/steamapps"
+  if [ ! -d ${steamapps_dir} ]; then
+    echo "steamapps dir not found. Creating..."
+    mkdir ${steamapps_dir}
+    chmod 755 ${steamapps_dir}
+  fi
+
+  library_file="${mount_point}/libraryfolder.vdf"
+  if [ ! -f ${library_file} ]; then
+    echo "libraryfolder.vdf not found. Creating..."
+    echo '"libraryfolder"
+  {
+  	"contentid"		""
+  	"label"		""
+  }' > ${library_file}
+    chown 1000:1000 ${library_file}
+  fi
+
+  desktop_dir="${mount_point}/SteamLibrary"
+  if [ -L ${desktop_dir} ]; then
+    echo "Removing old symlink to ${desktop_dir}"
+    rm ${desktop_dir}
+  fi
+
+  if [ ! -d ${desktop_dir} ]; then
+    echo "Desktop Libray not found. Creating..."
+    mkdir ${desktop_dir}
+  fi
+
+  if [ ! -L "${desktop_dir}/steamapps" ]; then
+    echo "Adding symlink to steamapps dir"
+    ln -s ${steamapps_dir} "${desktop_dir}/steamapps"
+  fi
+
+  if [ ! -L "${desktop_dir}/libraryfolder.vdf" ]; then
+    echo "Adding symlink to libraryfolder.vdf"
+    ln -s ${library_file} "${desktop_dir}/libraryfolder.vdf"
+  fi
+
+  chown -R 1000:1000 ${steamapps_dir}
+  chmod 755 ${library_file}
+  chown -R 1000:1000 ${desktop_dir}
+  chmod 755 "${desktop_dir}/libraryfolder.vdf"
+
+  # Clean up if we mounted ourself
+  if [ $SKIP_MOUNT == 0 ]; then
+    /bin/umount ${mount_point}
+    echo "Unmounted ${DEVICE} from ${mount_point}."
+  fi
+  echo "Steam Library initialized.
+}

--- a/usr/lib/media-support/init-media.sh
+++ b/usr/lib/media-support/init-media.sh
@@ -136,5 +136,5 @@ do_init()
     /bin/umount ${mount_point}
     echo "Unmounted ${DEVICE} from ${mount_point}."
   fi
-  echo "Steam Library initialized.
+  echo "Steam Library initialized."
 }

--- a/usr/lib/media-support/mount-media.sh
+++ b/usr/lib/media-support/mount-media.sh
@@ -84,13 +84,6 @@ do_mount()
   # Global mount options
   OPTS="rw,noatime"
 
-  # We need symlinks for Steam for now, so only automount ext4 as that's all
-  # Steam will format right now
-  if [[ ${ID_FS_TYPE} != "ext4" ]]; then
-    echo "Error mounting ${DEVICE}: wrong fstype: ${ID_FS_TYPE} - ${dev_json}"
-    exit 0
-  fi
-
   # Prior to talking to udisks, we need all udev hooks (we were started by one) to finish, so we know it has knowledge
   # of the drive.  Our own rule starts us as a service with --no-block, so we can wait for rules to settle here
   # safely.
@@ -132,51 +125,16 @@ do_mount()
     rm -rf "${mount_point}/lost+found"
   fi
 
-  # Build the file structure manually, if necessary.
+  # Check if this is a steam library.
   steamapps_dir="${mount_point}/steamapps"
   if [ ! -d ${steamapps_dir} ]; then
-    echo "steamapps dir not found. Creating..."
-    mkdir ${steamapps_dir}
-  fi
-
-  library_file="${mount_point}/libraryfolder.vdf"
-  if [ ! -f ${library_file} ]; then
-    echo "libraryfolder.vdf not found. Creating..."
-    echo '"libraryfolder"
-  {
-  	"contentid"		""
-  	"label"		""
-  }' > ${library_file}
-  fi
-
-  desktop_dir="${mount_point}/SteamLibrary"
-  if [ -L ${desktop_dir} ]; then
-    echo "Removing old symlink to ${desktop_dir}"
-    rm ${desktop_dir}
-  fi
-
-  if [ ! -d ${desktop_dir} ]; then
-    echo "Desktop Libray not found. Creating..."
-    mkdir ${desktop_dir}
-  fi
-
-  if [ ! -L "${desktop_dir}/steamapps" ]; then
-    echo "Adding symlink to steamapps dir"
-    ln -s ${steamapps_dir} "${desktop_dir}/steamapps"
-  fi
-
-  if [ ! -L "${desktop_dir}/libraryfolder.vdf" ]; then
-    echo "Adding symlink to libraryfolder.vdf"
-    ln -s ${library_file} "${desktop_dir}/libraryfolder.vdf"
-  fi
-
-  echo "Setting user permissions for ${mount_point}..."
-  chown -R 1000:1000 ${mount_point}
-  chmod 755 ${library_file}
-
+    echo "Unable to find a steamapps dir. Device is not a library. Run init-media to build steam library. Nothing else to do."
+    return
   # If Steam is running, notify it.
-  send_steam_url "addlibraryfolder" $mount_point
-  echo "${DEVICE} added as a steam library at ${mount_point}"
+  else;
+    send_steam_url "addlibraryfolder" $mount_point
+    echo "${DEVICE} added as a steam library at ${mount_point}"
+  fi
 }
 
 do_unmount()

--- a/usr/lib/media-support/mount-media.sh
+++ b/usr/lib/media-support/mount-media.sh
@@ -131,7 +131,7 @@ do_mount()
     echo "Unable to find a steamapps dir. Device is not a library. Run init-media to build steam library. Nothing else to do."
     return
   # If Steam is running, notify it.
-  else;
+  else
     send_steam_url "addlibraryfolder" $mount_point
     echo "${DEVICE} added as a steam library at ${mount_point}"
   fi

--- a/usr/share/polkit-1/actions/org.shadowblip.media-support.policy
+++ b/usr/share/polkit-1/actions/org.shadowblip.media-support.policy
@@ -18,6 +18,17 @@
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/shadowblip/format-media</annotate>
   </action>
 
+  <action id="org.shadowblip.pkexec.run-init-media">
+    <description>Add existing removable media partition as a Steam library</description>
+    <icon_name>package-x-generic</icon_name> 
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/shadowblip/init-media</annotate>
+  </action>
+
   <action id="org.shadowblip.pkexec.run-format-sdcard">
     <description>Run the Steam GamepadUI Format SD Card function</description>
     <icon_name>package-x-generic</icon_name> 
@@ -52,4 +63,3 @@
   </action>
 
 </policyconfig>
-


### PR DESCRIPTION
Currently the way media-mount works can cause issues on dual boot systems as the entire drive will be mounted and chowned to gamer, causing boot failure on the other OS. This moves the steam library initialization (back) to a separate script that can be manually triggered if desired, and will only affect the steam library that is created.